### PR TITLE
feat: Add `—versionFilePathPrefix` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ In your `package.json`, add call to `generate-version` after the build is create
 |  `-b`, `--buildPath`  | Set custom build path. This should be the root of the public directory that is served.                                                                                                                                                                  |     `build`     |
 |  `-i`, `--indexFile`  | Path to index.html relative to build path.                                                                                                                                                                                                              |  `index.html`   |
 | `-v`, `--versionFile` | Version file target path relative to build path.                                                                                                                                                                                                        | `version.json`  |
+| `-p`, `--versionFilePathPrefix` | A prefix to add before the versionFile option above (useful for more control over the deployed version file target path e.g. when using subdirectories to host your React app).|   |
 
 ### 2. Using a React hook
 

--- a/bin/generate-version.js
+++ b/bin/generate-version.js
@@ -53,7 +53,7 @@ function generate(argv) {
 
   const loadedIndex = cheerio.load(indexFile.toString());
   loadedIndex('head').append(
-    `<script>window.__APP_VERSION__ = "${appVersion}"; window.__APP_VERSION_FILE__ = "${argv.v}"</script>`
+    `<script>window.__APP_VERSION__ = "${appVersion}"; window.__APP_VERSION_FILE__ = "${argv.p}${argv.v}"</script>`
   );
   fs.writeFileSync(indexPath, loadedIndex.html());
 }
@@ -84,6 +84,12 @@ const argv = yargs
     description: 'Version file target path relative to build root',
     nargs: 1,
     default: 'version.json',
+  })
+  .option('versionFilePathPrefix', {
+    alias: 'p',
+    description: 'A prefix to add before the versionFile option',
+    nargs: 1,
+    default: '',
   })
   .example('$0 -b build/my-custom-build-root')
   .example('$0 -i index.html')


### PR DESCRIPTION
Thanks for a great library! I just added this option as I needed it and am currently doing some hacky post-build Node string replacement to resolve it. So would be great if this could be merged.

Scenario: I have 2 React apps hosted at app.com/subdirectory1 and app.com/subdirectory2. I need the version.json for each app to be served from the correct subdirectory, but served from the normal build directory. 

In Vite this is known as the ‘base’ and now this option allows for specification of the correct subdirectory (e.g. —versionFilePathPrefix=subdirectory1/) so that the version.json path is output as `subdirectory1/version.json` in the HTML.